### PR TITLE
jstat process is not stopped when using -s and -y arguments

### DIFF
--- a/jtune.py
+++ b/jtune.py
@@ -246,7 +246,8 @@ def liverun(cmd=None):
     # while getting the data 'live'. itertools.izip_longest seemed like it'd
     # almost do it, but it caches the results before sending it out...
     proc = sp.Popen(shlex.split(cmd), stdout=sp.PIPE, stderr=sp.STDOUT, env=env)
-
+    atexit.register(proc.terminate)
+	
     return iter(proc.stdout.readline, b'')
 
 


### PR DESCRIPTION
when using -s and -y arguments the jstat process is not stopped as there are 
1. No options send to jstat to stop after n iterations and
2. No option to send the keyboard interruption